### PR TITLE
Do not parse arguments if log is disabled by priority

### DIFF
--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -431,16 +431,16 @@ in a later version. Use \`${newUsage}\` instead`);
       break;
     }
 
+    newOpts.priority = this._normalizePriority(priority);
+
     // Resolve functions into strings by calling them
     if (typeof newOpts.message === 'function') {
-      newOpts.message = newOpts.message();
+      newOpts.message = this._shouldLog(newOpts.priority) ? newOpts.message() : '';
     }
     // 'log message must be a string' or object
     assert(typeof newOpts.message === 'string' || typeof newOpts.message === 'object');
 
-    return Object.assign(newOpts, {
-      priority: this._normalizePriority(priority)
-    }, opts);
+    return Object.assign(newOpts, opts);
   }
 
   _decorateMessage(message, opts) {


### PR DESCRIPTION
Skip calling `_getElapsedTime` etc. if the current priority is disabled.