### PR TITLE
Add APIs for saving screenshot to disk

### DIFF
--- a/docs/api-reference/test-utils/browser-test-driver.md
+++ b/docs/api-reference/test-utils/browser-test-driver.md
@@ -131,11 +131,13 @@ Request a pixel diff between the current page and a reference "golden image." Th
 * `tolerance` (Number, optional) - the tolerance when comparing two pixels. Between `0` (strict color match) to `1` (anything will pass). Default `0.1`.
 * `includeAA` (Boolean, optional) - If `true`, all pixels are compared. Otherwise detect and ignore anti-aliased pixels. Default `false`.
 * `createDiffImage` (Boolean, optional) - if `true`, will generate binary image data that highlight the mismatched pixels. Default `false`.
-* `saveOnFail` (Boolean|String, optional) - if truthy, any screenshots that failed to meet the target matching rate will be saved to disk for further investigation. If `true`, the filename will be `[name]-failed.png`, where `[name]` is replaced by the golden image path. If a string is supplied, will be used as the template for the target filename. Default `false`.
+* `saveOnFail` (Boolean, optional) - if `true`, any screenshots that failed to meet the target matching rate will be saved to disk for further investigation. Default `false`.
+* `saveAs` (String, optional) - the filename to save the screenshot as. If the string contains `[name]`, it will be replaced by the golden image path. Default `[name]-failed.png`.
 
 Returns: a `Promise` that resolves to an object with the following fields:
 
 * `success` (Boolean) - whether the test passed. A test can fail either because the matching score is lower than the specified `threshold`, or an unexpected error occurred.
+* `headless` (Boolean) - whether the browser was running in headless mode.
 * `match` (Number) - the matching score. Between `0` (no pixels matched) to `1` (all pixels matched).
 * `matchPercentage` (String) - `match` formatted in percentage form.
 * `diffImage` (Uint8Array) - image data that highlight the mismatched pixels. Only if `createDiffImage: true`.

--- a/docs/api-reference/test-utils/browser-test-driver.md
+++ b/docs/api-reference/test-utils/browser-test-driver.md
@@ -131,7 +131,7 @@ Request a pixel diff between the current page and a reference "golden image." Th
 * `tolerance` (Number, optional) - the tolerance when comparing two pixels. Between `0` (strict color match) to `1` (anything will pass). Default `0.1`.
 * `includeAA` (Boolean, optional) - If `true`, all pixels are compared. Otherwise detect and ignore anti-aliased pixels. Default `false`.
 * `createDiffImage` (Boolean, optional) - if `true`, will generate binary image data that highlight the mismatched pixels. Default `false`.
-* `saveOnFail` (String, optional) - the filename to save failed screenshots to. If supplied, any screenshots that failed to meet the target matching rate will be saved to disk for further investigation. For example, `[name]-actual.png` saves the screenshot to where the golden image is, with the suffix `-actual.png`. Default `null`.
+* `saveOnFail` (Boolean|String, optional) - if truthy, any screenshots that failed to meet the target matching rate will be saved to disk for further investigation. If `true`, the filename will be `[name]-failed.png`, where `[name]` is replaced by the golden image path. If a string is supplied, will be used as the template for the target filename. Default `false`.
 
 Returns: a `Promise` that resolves to an object with the following fields:
 

--- a/docs/api-reference/test-utils/browser-test-driver.md
+++ b/docs/api-reference/test-utils/browser-test-driver.md
@@ -97,6 +97,20 @@ window.browserTestDriver_finish('Congratulations! All tests passed.');
 
 Notify the node script that the app has finished executing and the browser should be closed.
 
+### browserTestDriver_isHeadless()
+
+```js
+window.browserTestDriver_isHeadless().then(isHeadless => {
+  if (isHeadless) {
+    console.log('Test is running in headless mode');
+  }
+});
+```
+
+Check if the current test environment is headless.
+
+Returns a `Promise` that resolves to `true` if the current test environment is headless.
+
 ### browserTestDriver_captureAndDiffScreen(options : Object)
 
 ```js
@@ -104,6 +118,8 @@ window.browserTestDriver_captureAndDiffScreen({
   goldenImage: './golden-images/map.png',
   region: {x: 0, y: 0, width: 800, height: 600},
   threshold: 0.99
+}).then(result => {
+  // do something
 });
 ```
 
@@ -115,6 +131,7 @@ Request a pixel diff between the current page and a reference "golden image." Th
 * `tolerance` (Number, optional) - the tolerance when comparing two pixels. Between `0` (strict color match) to `1` (anything will pass). Default `0.1`.
 * `includeAA` (Boolean, optional) - If `true`, all pixels are compared. Otherwise detect and ignore anti-aliased pixels. Default `false`.
 * `createDiffImage` (Boolean, optional) - if `true`, will generate binary image data that highlight the mismatched pixels. Default `false`.
+* `saveOnFail` (String, optional) - the filename to save failed screenshots to. If supplied, any screenshots that failed to meet the target matching rate will be saved to disk for further investigation. For example, `[name]-actual.png` saves the screenshot to where the golden image is, with the suffix `-actual.png`. Default `null`.
 
 Returns: a `Promise` that resolves to an object with the following fields:
 

--- a/docs/api-reference/test-utils/browser-test-driver.md
+++ b/docs/api-reference/test-utils/browser-test-driver.md
@@ -10,7 +10,7 @@ A higher level helper class that inherits the [`BrowserDriver`](./docs/api-refer
 
 A `BrowserTestDriver` starts a Chromium browser instance and a server and opens a page with a URL that loads a script from the server. The script that runs in the browser is expected to report test results back using predefined global functions.
 
-To use this class, [puppeteer](https://www.npmjs.com/package/puppeteer) must be installed as a dev dependency.
+To use this class, [puppeteer](https://www.npmjs.com/package/puppeteer) and [pixelmatch](https://www.npmjs.com/package/pixelmatch) must be installed as dev dependencies.
 
 ## Usage
 

--- a/src/test-utils/browser-automation/browser-test-driver.js
+++ b/src/test-utils/browser-automation/browser-test-driver.js
@@ -181,10 +181,8 @@ export default class BrowserTestDriver extends BrowserDriver {
       .then(image => diffImages(image, opts.goldenImage, opts))
       .then(result => {
         if (!result.success && opts.saveOnFail) {
-          let filename = opts.saveOnFail;
-          if (typeof filename !== 'string') {
-            filename = '[name]-failed.png';
-          }
+          let filename =
+            typeof opts.saveOnFail === 'string' ? opts.saveOnFail : '[name]-failed.png';
           filename = filename.replace('[name]', opts.goldenImage.replace(/\.\w+$/, ''));
           this._saveScreenshot(filename, result.source1);
         }

--- a/src/test-utils/browser-automation/browser-test-driver.js
+++ b/src/test-utils/browser-automation/browser-test-driver.js
@@ -21,6 +21,7 @@
 import BrowserDriver from './browser-driver';
 import {COLOR, addColor} from '../../lib/utils/color';
 import diffImages from '../image-utils/diff-images';
+import fs from 'fs';
 
 const MAX_CONSOLE_MESSAGE_LENGTH = 500;
 
@@ -57,6 +58,7 @@ export default class BrowserTestDriver extends BrowserDriver {
       _ =>
         new Promise((resolve, reject) => {
           const exposeFunctions = Object.assign({}, config.exposeFunctions, {
+            browserTestDriver_isHeadless: () => this.headless,
             browserTestDriver_fail: () => this.failures++,
             browserTestDriver_finish: message => resolve(message),
             browserTestDriver_captureAndDiffScreen: opts => this._captureAndDiff(opts),
@@ -177,8 +179,39 @@ export default class BrowserTestDriver extends BrowserDriver {
     return this.page
       .screenshot(screenshotOptions)
       .then(image => diffImages(image, opts.goldenImage, opts))
+      .then(result => {
+        if (!result.success && opts.saveOnFail) {
+          let filename = opts.saveOnFail;
+          if (typeof filename !== 'string') {
+            filename = '[name]-failed.png';
+          }
+          filename = filename.replace('[name]', opts.goldenImage.replace(/\.\w+$/, ''));
+          this._saveScreenshot(filename, result.source1);
+        }
+        return {
+          match: result.match,
+          matchPercentage: result.matchPercentage,
+          success: result.success,
+          diffImage: result.diffImage
+        };
+      })
       .catch(error => {
         return {success: false, match: 0, error: error.message};
       });
+  }
+
+  _saveScreenshot(filename, data) {
+    this.logger.log({
+      message: `Writing screenshot to ${filename}`,
+      color: COLOR.BRIGHT_YELLOW
+    })();
+    fs.writeFile(filename, data, error => {
+      if (error) {
+        this.logger.log({
+          message: `Save screenshot failed: ${error.message}`,
+          color: COLOR.BRIGHT_RED
+        })();
+      }
+    });
   }
 }

--- a/src/test-utils/browser-automation/browser-test-driver.js
+++ b/src/test-utils/browser-automation/browser-test-driver.js
@@ -181,12 +181,12 @@ export default class BrowserTestDriver extends BrowserDriver {
       .then(image => diffImages(image, opts.goldenImage, opts))
       .then(result => {
         if (!result.success && opts.saveOnFail) {
-          let filename =
-            typeof opts.saveOnFail === 'string' ? opts.saveOnFail : '[name]-failed.png';
+          let filename = opts.saveAs || '[name]-failed.png';
           filename = filename.replace('[name]', opts.goldenImage.replace(/\.\w+$/, ''));
           this._saveScreenshot(filename, result.source1);
         }
         return {
+          headless: this.headless,
           match: result.match,
           matchPercentage: result.matchPercentage,
           success: result.success,
@@ -194,7 +194,13 @@ export default class BrowserTestDriver extends BrowserDriver {
         };
       })
       .catch(error => {
-        return {success: false, match: 0, error: error.message};
+        return {
+          headless: this.headless,
+          match: 0,
+          matchPercentage: 'N/A',
+          success: false,
+          error: error.message
+        };
       });
   }
 

--- a/src/test-utils/image-utils/diff-images.js
+++ b/src/test-utils/image-utils/diff-images.js
@@ -4,9 +4,14 @@ import {PNG} from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
 export default function diffImages(source1, source2, options = {}) {
-  return Promise.all([parsePNG(source1), parsePNG(source2)]).then(([image1, image2]) =>
-    diffPNGs(image1, image2, options)
-  );
+  return Promise.all([parsePNG(source1), parsePNG(source2)]).then(([image1, image2]) => {
+    const result = diffPNGs(image1, image2, options);
+    return Object.assign(result, {
+      source1,
+      source2,
+      options
+    });
+  });
 }
 
 function diffPNGs(image1, image2, options) {


### PR DESCRIPTION
- New exposed function `browserTestDriver_isHeadless()` for detecting the test environment from the web app. This is needed to adjust pixel matching tolerance when under headless mode.
- Add `saveOnFail` option to `browserTestDriver_captureAndDiffScreen`.