### PR TITLE
Simplify isHeadless global

### DIFF
--- a/docs/api-reference/test-utils/browser-test-driver.md
+++ b/docs/api-reference/test-utils/browser-test-driver.md
@@ -76,7 +76,7 @@ Parameters:
 * `url` (String) - if supplied, will be used instead of the URL returned by the dev server.
 
 
-## Built-in Exposed Functions
+## Built-in Exposed Globals
 
 The `BrowserTestDriver` instance exposes a series of global functions to the browser application.
 The following functions can be called from the browser application to communicate with the nodejs script:
@@ -97,19 +97,16 @@ window.browserTestDriver_finish('Congratulations! All tests passed.');
 
 Notify the node script that the app has finished executing and the browser should be closed.
 
-### browserTestDriver_isHeadless()
+### browserTestDriver_isHeadless
 
 ```js
-window.browserTestDriver_isHeadless().then(isHeadless => {
-  if (isHeadless) {
-    console.log('Test is running in headless mode');
-  }
-});
+if (window.browserTestDriver_isHeadless) {
+  console.log('Test is running in headless mode');
+}
 ```
 
-Check if the current test environment is headless.
+Truthy if the current test environment is headless.
 
-Returns a `Promise` that resolves to `true` if the current test environment is headless.
 
 ### browserTestDriver_captureAndDiffScreen(options : Object)
 

--- a/modules/test-utils/src/browser-automation/browser-test-driver.js
+++ b/modules/test-utils/src/browser-automation/browser-test-driver.js
@@ -65,6 +65,9 @@ export default class BrowserTestDriver extends BrowserDriver {
             onerror: reject
           });
 
+          // Puppeteer can only inject functions, not values, into the global scope
+          // In headless mode, we inject the function so it's truthy
+          // In non-headless mode, we don't inject the function so it's undefined
           if (this.headless) {
             exposeFunctions.browserTestDriver_isHeadless = () => true;
           }

--- a/modules/test-utils/src/browser-automation/browser-test-driver.js
+++ b/modules/test-utils/src/browser-automation/browser-test-driver.js
@@ -58,13 +58,16 @@ export default class BrowserTestDriver extends BrowserDriver {
       _ =>
         new Promise((resolve, reject) => {
           const exposeFunctions = Object.assign({}, config.exposeFunctions, {
-            browserTestDriver_isHeadless: () => this.headless,
             browserTestDriver_fail: () => this.failures++,
             browserTestDriver_finish: message => resolve(message),
             browserTestDriver_captureAndDiffScreen: opts => this._captureAndDiff(opts),
             // Capture any uncaught errors
             onerror: reject
           });
+
+          if (this.headless) {
+            exposeFunctions.browserTestDriver_isHeadless = () => true;
+          }
 
           // Legacy config
           if (config.exposeFunction) {


### PR DESCRIPTION
`browserTestDriver_isHeadless` was an async function which is cumbersome to use.
With this change, `browserTestDriver_isHeadless` is a function if in headless mode, and `undefined` otherwise.