### PR TITLE
Fix: saveOnFail does not work if an error is thrown

### DIFF
--- a/modules/test-utils/src/browser-automation/browser-test-driver.js
+++ b/modules/test-utils/src/browser-automation/browser-test-driver.js
@@ -186,17 +186,18 @@ export default class BrowserTestDriver extends BrowserDriver {
       .screenshot(screenshotOptions)
       .then(image => diffImages(image, opts.goldenImage, opts))
       .then(result => {
-        if (!result.success && opts.saveOnFail) {
+        if (!result.success && opts.saveOnFail && result.source1) {
           let filename = opts.saveAs || '[name]-failed.png';
           filename = filename.replace('[name]', opts.goldenImage.replace(/\.\w+$/, ''));
           this._saveScreenshot(filename, result.source1);
         }
         return {
           headless: this.headless,
-          match: result.match,
-          matchPercentage: result.matchPercentage,
+          match: result.match || 0,
+          matchPercentage: result.matchPercentage || 'N/A',
           success: result.success,
-          diffImage: result.diffImage
+          diffImage: result.diffImage || null,
+          error: result.error || null
         };
       })
       .catch(error => {

--- a/modules/test-utils/src/utils/diff-images.js
+++ b/modules/test-utils/src/utils/diff-images.js
@@ -4,14 +4,19 @@ import {PNG} from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
 export default function diffImages(source1, source2, options = {}) {
-  return Promise.all([parsePNG(source1), parsePNG(source2)]).then(([image1, image2]) => {
-    const result = diffPNGs(image1, image2, options);
-    return Object.assign(result, {
-      source1,
-      source2,
-      options
-    });
-  });
+  return Promise.all([parsePNG(source1), parsePNG(source2)])
+    .then(([image1, image2]) => diffPNGs(image1, image2, options))
+    .catch(error => ({
+      success: false,
+      error: error.message
+    }))
+    .then(result =>
+      Object.assign(result, {
+        source1,
+        source2,
+        options
+      })
+    );
 }
 
 function diffPNGs(image1, image2, options) {


### PR DESCRIPTION
Improve error handling in the following cases:
- Golden image size does not match screenshot
- Golden image cannot be loaded