### PR TITLE
Hi-res timer for benchmarks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,10 @@
     "guard-for-in": 0,
     "no-inline-comments": 0,
     "camelcase": 0
+  },
+  "globals": {
+    "performance": true,
+    "process": true
   }
 }
 

--- a/modules/bench/src/bench.js
+++ b/modules/bench/src/bench.js
@@ -2,6 +2,7 @@
 /* global setTimeout, console */
 import {global, assert, rightPad, autobind, LocalStorage} from 'probe.gl';
 import {formatSI} from './format-utils';
+import timer from './timer';
 
 const noop = () => {};
 
@@ -51,13 +52,13 @@ export default class Bench {
   }
 
   run() {
-    const timer = new Date();
+    const timeStart = timer();
 
     const {tests, onBenchmarkComplete} = this;
     const promise = runAsyncTests({tests, onBenchmarkComplete});
 
     promise.then(() => {
-      const elapsed = (new Date() - timer) / 1000;
+      const elapsed = (timer() - timeStart) / 1000;
       logEntry(this, {entry: LOG_ENTRY.COMPLETE, time: elapsed, message: 'Complete'});
       this.onSuiteComplete();
     });
@@ -210,9 +211,9 @@ function runBenchTest(test) {
       multiplier = (test.opts.time / elapsedMillis) * 1.25;
     }
     iterations *= multiplier;
-    const timer = new Date();
+    const timeStart = timer();
     runBenchTestIterations(test, iterations);
-    elapsedMillis = new Date() - timer;
+    elapsedMillis = timer() - timeStart;
   }
 
   const time = elapsedMillis / 1000;

--- a/modules/bench/src/timer.js
+++ b/modules/bench/src/timer.js
@@ -1,0 +1,19 @@
+let timer;
+
+// Get best timer available.
+if (typeof performance !== 'undefined') {
+  timer = () => {
+    return performance.now();
+  };
+} else if (typeof process !== 'undefined') {
+  timer = () => {
+    const timeParts = process.hrtime();
+    return timeParts[0] * 1000 + timeParts[1] / 1e6;
+  };
+} else {
+  timer = () => {
+    return Date.now();
+  };
+}
+
+export default timer;


### PR DESCRIPTION
I noticed `Date` is used for timing in the benchmarks, which will lose sub-millisecond measurements. This update will get the best timer available for the platform: `performance` in the browser, `hrtime` in node, fallback to `Date` in other cases.