### PR TITLE
More stats updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
     "prettier/prettier": "error",
     "guard-for-in": 0,
     "no-inline-comments": 0,
-    "camelcase": 0
+    "camelcase": 0,
+    "sort-vars": 0
   },
   "globals": {
     "performance": true,

--- a/docs/api-reference/log/stats.md
+++ b/docs/api-reference/log/stats.md
@@ -36,7 +36,9 @@ Returns the `Stat` object identified by `name`.
 
 ### reset
 
-Resets all stats etc.
+Resets all stats.
+
+`stats.reset()`
 
 
 ### forEach
@@ -47,6 +49,8 @@ Iterate over all stats.
 
 * `fn` (`Function`, required) - function to call on each `Stat` object.
 
-### getTimers
+### getTable
 
-`stats.getTimers
+Return stats in a format suitable for `console.table`
+
+`stats.getTable()`

--- a/docs/api-reference/stats-widget/stats-widget.md
+++ b/docs/api-reference/stats-widget/stats-widget.md
@@ -32,9 +32,10 @@ statsWidget.update();
   - `framesPerUpdate` (`Number`) - number of times `update` must be called before the widget is re-rendered. Allows the application
     to call `update` each frame with re-renders occuring at a slower rate.
   - `container` (DOMElement) - DOM element to use as container for the widget. Will be created internally if not provided.
-  - `css` (`Object`) - css properties to apply to the container `div` of the widget.
-  - `headerCSS` (`Object`) - css properties to apply to the header `div` of the widget.
-  - `itemCSS` (`Object`) - css properties to apply to the individual item `div`s for each stat displayed in the widget.
+  - `css` (`Object`) - css properties to apply to the container `div` of the widget. Two special keys can be used to modify the
+    style of nested elements:
+    + `header` (`Object`) - css properties to apply to the header `div` of the widget.
+    + `item` (`Object`) - css properties to apply to the individual item `div`s for each stat displayed in the widget.
   - `formatters` (`Object`) - text formatters to use to display a stat. Keys are the stat's `id`. Value can either be
     a function that takes a single `stat` object as argument, or one of the following strings:
     + `count`: Display as a simple count.

--- a/docs/api-reference/stats-widget/stats-widget.md
+++ b/docs/api-reference/stats-widget/stats-widget.md
@@ -33,8 +33,8 @@ statsWidget.update();
     to call `update` each frame with re-renders occuring at a slower rate.
   - `container` (DOMElement) - DOM element to use as container for the widget. Will be created internally if not provided.
   - `css` (`Object`) - css properties to apply to the container `div` of the widget.
-  - `headerCss` (`Object`) - css properties to apply to the header `div` of the widget.
-  - `itemCss` (`Object`) - css properties to apply to the individual item `div`s for each stat displayed in the widget.
+  - `headerCSS` (`Object`) - css properties to apply to the header `div` of the widget.
+  - `itemCSS` (`Object`) - css properties to apply to the individual item `div`s for each stat displayed in the widget.
   - `formatters` (`Object`) - text formatters to use to display a stat. Keys are the stat's `id`. Value can either be
     a function that takes a single `stat` object as argument, or one of the following strings:
     + `count`: Display as a simple count.

--- a/docs/api-reference/stats-widget/stats-widget.md
+++ b/docs/api-reference/stats-widget/stats-widget.md
@@ -41,7 +41,7 @@ statsWidget.update();
     + `averageTime`: Display average time.
     + `totalTime`: Display total time.
     + `fps`: Display Hz as a frame rate.
-    + `memory`: Display count a memory measurement.
+    + `memory`: Display count as a memory measurement.
   - `resetOnUpdate` (`Object`) - whether the a stat should be reset each time the widget is re-rendered. Keyed by the stat's `id`.
 
 ### setFormatter

--- a/docs/api-reference/stats-widget/stats-widget.md
+++ b/docs/api-reference/stats-widget/stats-widget.md
@@ -13,10 +13,9 @@ import StatsWidget from '@probe.gl/stats-widget';
 const stats = new Stats({id: 'My Stats'});
 const counter = stats.get('Counter');
 const statsWidget = new StatsWidget(stats);
-statsWidget.setFormatter('Counter', 'stat' => `Count: ${stat.count}`);
 
 for (let i = 0; i < 100; i++) {
-  stats.addCount(i);
+  counter.addCount(i);
 }
 statsWidget.update();
 ```
@@ -25,20 +24,25 @@ statsWidget.update();
 
 ### constructor
 
-`new StatsWidget(statsInstance, styles)`
+`new StatsWidget(stats, opts)`
 
-* `statsInstance` (`Stats`) - a probe.gl [Stats](/docs/api-reference/log/stats.md) instance.
-* `styles` (Object, optional)
-  - `container` (DOMElement) - an element to use as the container of the widget. If not provided, a new `div` will be appended to the document as the container.
-  - `containerStyle` (String) - css text for the container. Only applied if using the default container.
-  - `width` (Number) - width of the widget, in pixels
-  - `color` (String) - css color for the text
-  - `background` (String) - css color for the background
-  - `padding` (Array) - [horizontal, vertical] padding, in pixels
-  - `fontFamily` (String) - css font family for the text
-  - `headerSize` (Number) - font size of the header
-  - `fontSize` (Number) - font size of the body
-  - `lineSpacing` (Number) - spacing between lines, in pixels
+* `stats` (`Stats`) - a probe.gl [Stats](/docs/api-reference/log/stats.md) instance.
+* `opts` (`Object`, optional)
+  - `title` (`String`) - header text for the widget. Defaults to the `id` of the `Stats` object.
+  - `framesPerUpdate` (`Number`) - number of times `update` must be called before the widget is re-rendered. Allows the application
+    to call `update` each frame with re-renders occuring at a slower rate.
+  - `container` (DOMElement) - DOM element to use as container for the widget. Will be created internally if not provided.
+  - `css` (`Object`) - css properties to apply to the container `div` of the widget.
+  - `headerCss` (`Object`) - css properties to apply to the header `div` of the widget.
+  - `itemCss` (`Object`) - css properties to apply to the individual item `div`s for each stat displayed in the widget.
+  - `formatters` (`Object`) - text formatters to use to display a stat. Keys are the stat's `id`. Value can either be
+    a function that takes a single `stat` object as argument, or one of the following strings:
+    + `count`: Display as a simple count.
+    + `averageTime`: Display average time.
+    + `totalTime`: Display total time.
+    + `fps`: Display Hz as a frame rate.
+    + `memory`: Display count a memory measurement.
+  - `resetOnUpdate` (`Object`) - whether the a stat should be reset each time the widget is re-rendered. Keyed by the stat's `id`.
 
 ### setFormatter
 

--- a/modules/core/src/lib/stat.js
+++ b/modules/core/src/lib/stat.js
@@ -51,12 +51,12 @@ export default class Stat {
 
   // Calculate average time / count
   getAverageTime() {
-    return this.count > 0 ? (this.time / this.count) : 0;
+    return this.count > 0 ? this.time / this.count : 0;
   }
 
   // Calculate counts per second
   getHz() {
-    return this.time > 0 ? (this.count / (this.time / 1000)) : 0;
+    return this.time > 0 ? this.count / (this.time / 1000) : 0;
   }
 
   reset() {

--- a/modules/core/src/lib/stat.js
+++ b/modules/core/src/lib/stat.js
@@ -51,12 +51,12 @@ export default class Stat {
 
   // Calculate average time / count
   getAverageTime() {
-    return this.time / this.count;
+    return this.count > 0 ? (this.time / this.count) : 0;
   }
 
   // Calculate counts per second
   getHz() {
-    return this.count / (this.time / 1000);
+    return this.time > 0 ? (this.count / (this.time / 1000)) : 0;
   }
 
   reset() {

--- a/modules/core/src/lib/stats.js
+++ b/modules/core/src/lib/stats.js
@@ -27,4 +27,18 @@ export default class Stats {
       fn(this.stats[key]);
     }
   }
+
+  getTable() {
+    const table = {};
+    this.forEach(stat => {
+      table[stat.name] = {
+        time: stat.time || 0,
+        count: stat.count || 0,
+        average: stat.getAverageTime() || 0,
+        hz: stat.getHz() || 0
+      };
+    });
+
+    return table;
+  }
 }

--- a/modules/stats-widget/src/stats-widget.js
+++ b/modules/stats-widget/src/stats-widget.js
@@ -13,10 +13,10 @@ const DEFAULT_CSS = {
     fontSize: '12px',
     lineSpacing: 6
   },
-  headerCss: {
+  headerCSS: {
     fontSize: '16px'
   },
-  itemCss: {
+  itemCSS: {
     paddingLeft: '8px'
   }
 };
@@ -38,8 +38,8 @@ export default class StatsWidget {
     this.title = opts.title || null;
     this.stats = stats;
     this._css = Object.assign({}, DEFAULT_CSS.css, opts.css);
-    this._headerCss = Object.assign({}, DEFAULT_CSS.headerCss, opts.headerCss);
-    this._itemCss = Object.assign({}, DEFAULT_CSS.itemCss, opts.itemCss);
+    this._headerCSS = Object.assign({}, DEFAULT_CSS.headerCSS, opts.headerCSS);
+    this._itemCSS = Object.assign({}, DEFAULT_CSS.itemCSS, opts.itemCSS);
     this._container = null;
     this._header = null;
     this._items = {};
@@ -98,15 +98,15 @@ export default class StatsWidget {
 
     this._header = document.createElement('div');
     this._header.innerText = this.title || this.stats.id;
-    for (const name in this._headerCss) {
-      this._header.style[name] = this._headerCss[name];
+    for (const name in this._headerCSS) {
+      this._header.style[name] = this._headerCSS[name];
     }
     this._container.appendChild(this._header);
 
     this.stats.forEach(stat => {
       this._items[stat.name] = document.createElement('div');
-      for (const name in this._itemCss) {
-        this._items[stat.name].style[name] = this._itemCss[name];
+      for (const name in this._itemCSS) {
+        this._items[stat.name].style[name] = this._itemCSS[name];
       }
       this._container.appendChild(this._items[stat.name]);
     });

--- a/modules/stats-widget/src/stats-widget.js
+++ b/modules/stats-widget/src/stats-widget.js
@@ -38,8 +38,12 @@ export default class StatsWidget {
     this.title = opts.title || null;
     this.stats = stats;
     this._css = Object.assign({}, DEFAULT_CSS.css, opts.css);
-    this._headerCSS = Object.assign({}, DEFAULT_CSS.headerCSS, opts.headerCSS);
-    this._itemCSS = Object.assign({}, DEFAULT_CSS.itemCSS, opts.itemCSS);
+    this._headerCSS = Object.assign({}, DEFAULT_CSS.headerCSS, this._css.header);
+    this._itemCSS = Object.assign({}, DEFAULT_CSS.itemCSS, this._css.item);
+
+    delete this._css.header;
+    delete this._css.item;
+
     this._container = null;
     this._header = null;
     this._items = {};

--- a/modules/stats-widget/src/stats-widget.js
+++ b/modules/stats-widget/src/stats-widget.js
@@ -23,7 +23,8 @@ const DEFAULT_CSS = {
 
 const DEFAULT_FORMATTERS = {
   count: stat => `${stat.name}: ${stat.count}`,
-  time: stat => `${stat.name}: ${formatTime(stat.getAverageTime())}`,
+  averageTime: stat => `${stat.name}: ${formatTime(stat.getAverageTime())}`,
+  totalTime: stat => `${stat.name}: ${formatTime(stat.time)}`,
   fps: stat => `${stat.name}: ${Math.round(stat.getHz())}fps`,
   memory: stat => `${stat.name}: ${formatMemory(stat.count)}`
 };
@@ -65,7 +66,7 @@ export default class StatsWidget {
       }
     }
 
-    this._createDOM();
+    this._createDOM(opts.container);
   }
 
   update() {


### PR DESCRIPTION
- Restored `stats.getTable()` method to format stats suitably for `console.table`
- Created default formatters that can be indicated by name, e.g. "averageTime", "memory", "fps"
- Replaced canvas-based rendering with DOM. Simplifies the code a lot and allows for CSS to be fully customized
- `framesPerUpdate` option allows app to just call `update` each frame. Throttling is handled internally
- Per-stat `resetOnUpdate` option indicates that a stat should be reset every time the widget is re-rendered (i.e. every `framesPerUpdate` frames)
- `title` option can replace the `stats.id` as the widget's header
- Enabled eslint on `StatsWidget`

Putting that all together, the API looks like this:

```js
    const statsWidget = new StatsWidget(this.stats, {
      title: 'Render Time',
      framesPerUpdate: 60,
      css: {
        position: 'absolute',
        top: '20px',
        left: '20px'
      },
      formatters: {
        'CPU Time': 'time',
        'GPU Time': 'time',
        'Frame Rate': 'fps'
      },
      resetOnUpdate: {
        'CPU Time': true,
        'GPU Time': true,
        'Frame Rate': true
      }
    });
```

Closes #63 