### PR TITLE
Sample window

### DIFF
--- a/docs/api-reference/log/stat.md
+++ b/docs/api-reference/log/stat.md
@@ -31,19 +31,19 @@ memoryUsage.addCount(1024);
 memoryUsage.subtractCount(512);
 ```
 
-For time statistics, the `Stat` object can also define a sample window, to only update `count` and `time` after a given number of samples are taken:
+For time statistics, the `Stat` object can also define a sample window, to only update `count` or `time` after a given number of samples are taken:
 
 ```js
 const stats = new Stats({id: 'my-stats'});
 const executionTime = stats.get('Time').setSampleSize(3);
 executionTime.addTime(1);
 executionTime.addTime(2);
-// `count` and `time` are still 0 at this point
+// `time` is still 0 at this point
 executionTime.getHz();          // => 0
 executionTime.getAverageTime(); // => 0
 
 executionTime.addTime(3);
-// Now `count` = 3 and `time` = 6
+// Now `time` = 6
 executionTime.getAverageTime(); // => 2
 executionTime.addTime(1);
 executionTime.addTime(1);

--- a/docs/api-reference/log/stat.md
+++ b/docs/api-reference/log/stat.md
@@ -31,6 +31,27 @@ memoryUsage.addCount(1024);
 memoryUsage.subtractCount(512);
 ```
 
+For time statistics, the `Stat` object can also define a sample window, to only update `count` and `time` after a given number of samples are taken:
+
+```js
+const stats = new Stats({id: 'my-stats'});
+const executionTime = stats.get('Time').setSampleSize(3);
+executionTime.addTime(1);
+executionTime.addTime(2);
+// `count` and `time` are still 0 at this point
+executionTime.getHz();          // => 0
+executionTime.getAverageTime(); // => 0
+
+executionTime.addTime(3);
+// Now `count` = 3 and `time` = 6
+executionTime.getAverageTime(); // => 2
+executionTime.addTime(1);
+executionTime.addTime(1);
+executionTime.addTime(1);
+executionTime.getAverageTime();       // => 1.5
+executionTime.getSampleAverageTime(); // => 1 (only from the last sample set)
+```
+
 ## Properties
 
 ### name : String
@@ -47,10 +68,13 @@ Accumulated count or number of timings.
 
 Accumulated time from all timings.
 
-
 ### lastTiming : Number
 
 Last timing taken.
+
+### lastSampleTime : Number
+
+Timing of the last completed set of samples.
 
 
 ## Methods
@@ -127,7 +151,20 @@ Calculate the average number of timing events per second (i.e. `count / (time * 
 
 ### getAverageTime
 
-Calculate the average amount of time take per timing event in milliseconds (i.e. `time / count`.
+Calculate the average amount of time take per timing event in milliseconds (i.e. `time / count`).
+
+`stat.getAverageTime()`
+
+### getSampleHz
+
+Calculate the average number of timing events per second (i.e. `count / (time * 1000)` for the last completed set of samples.
+
+`stat.getHz()`
+
+
+### getSampleAverageTime
+
+Calculate the average amount of time take per timing event in milliseconds (i.e. `time / count`) for the last completed set of samples.
 
 `stat.getAverageTime()`
 

--- a/docs/api-reference/log/stat.md
+++ b/docs/api-reference/log/stat.md
@@ -144,27 +144,40 @@ Increase `time` by `value` and increment `count` by `1`.
 
 ### getHz
 
-Calculate the average number of timing events per second (i.e. `count / (time * 1000)`.
+Calculate the average number of timing events per second (i.e. `samples / (time * 1000)`.
 
 `stat.getHz()`
 
 
 ### getAverageTime
 
-Calculate the average amount of time take per timing event in milliseconds (i.e. `time / count`).
+Calculate the average amount of time take per timing event in milliseconds (i.e. `time / samples`).
 
 `stat.getAverageTime()`
 
+### getAverageCount
+
+Calculate the average count per sampling (i.e. `count / samples`).
+
+`stat.getAverageCount()`
+
 ### getSampleHz
 
-Calculate the average number of timing events per second (i.e. `count / (time * 1000)` for the last completed set of samples.
+Calculate the average number of timing events per second (i.e. `samples / (time * 1000)` for the last completed set of samples.
 
 `stat.getHz()`
 
 
 ### getSampleAverageTime
 
-Calculate the average amount of time take per timing event in milliseconds (i.e. `time / count`) for the last completed set of samples.
+Calculate the average amount of time take per timing event in milliseconds (i.e. `time / samples`) for the last completed set of samples.
+
+`stat.getAverageTime()`
+
+
+### getSampleAverageCount
+
+Calculate the average count per sampling (i.e. `count / samples`) for the last completed set of samples.
 
 `stat.getAverageTime()`
 

--- a/modules/core/src/lib/stat.js
+++ b/modules/core/src/lib/stat.js
@@ -30,6 +30,7 @@ export default class Stat {
   // Increase count
   addCount(value) {
     this._count += value;
+    this._samples++;
     this._checkSampling();
 
     return this;
@@ -38,6 +39,7 @@ export default class Stat {
   // Decrease count
   subtractCount(value) {
     this._count -= value;
+    this._samples++;
     this._checkSampling();
 
     return this;
@@ -47,7 +49,7 @@ export default class Stat {
   addTime(time) {
     this._time += time;
     this._lastTiming = time;
-    this._count++;
+    this._samples++;
     this._checkSampling();
 
     return this;
@@ -74,32 +76,44 @@ export default class Stat {
     return this;
   }
 
+  getSampleAverageCount() {
+    return this.sampleSize > 0 ? this.lastSampleCount / this.sampleSize : 0;
+  }
+
   // Calculate average time / count for the previous window
   getSampleAverageTime() {
-    return this.lastSampleCount > 0 ? this.lastSampleTime / this.lastSampleCount : 0;
+    return this.sampleSize > 0 ? this.lastSampleTime / this.sampleSize : 0;
   }
 
   // Calculate counts per second for the previous window
   getSampleHz() {
-    return this.lastSampleTime > 0 ? this.lastSampleCount / (this.lastSampleTime / 1000) : 0;
+    return this.lastSampleTime > 0 ? this.sampleSize / (this.lastSampleTime / 1000) : 0;
+  }
+
+  getAverageCount() {
+    return this.samples > 0 ? this.count / this.samples : 0;
   }
 
   // Calculate average time / count
   getAverageTime() {
-    return this.count > 0 ? this.time / this.count : 0;
+    return this.samples > 0 ? this.time / this.samples : 0;
   }
 
   // Calculate counts per second
   getHz() {
-    return this.time > 0 ? this.count / (this.time / 1000) : 0;
+    return this.time > 0 ? this.samples / (this.time / 1000) : 0;
   }
 
   reset() {
     this.time = 0;
     this.count = 0;
+    this.samples = 0;
     this.lastTiming = 0;
-    this._time = 0;
+    this.lastSampleTime = 0;
+    this.lastSampleCount = 0;
     this._count = 0;
+    this._time = 0;
+    this._samples = 0;
     this._startTime = 0;
     this._timerPending = false;
 
@@ -107,13 +121,15 @@ export default class Stat {
   }
 
   _checkSampling() {
-    if (this._count === this.sampleSize) {
-      this.lastSampleCount = this._count;
+    if (this._samples === this.sampleSize) {
       this.lastSampleTime = this._time;
+      this.lastSampleCount = this._count;
       this.count += this._count;
       this.time += this._time;
+      this.samples += this._samples;
       this._time = 0;
       this._count = 0;
+      this._samples = 0;
     }
   }
 }

--- a/modules/core/src/lib/stat.js
+++ b/modules/core/src/lib/stat.js
@@ -1,52 +1,87 @@
 import getHiResTimestamp from '../utils/hi-res-timestamp';
 
 export default class Stat {
-  constructor(name) {
+  constructor(name, samples) {
     this.name = name;
+    this.sampleSize = 1;
     this.reset();
+  }
+
+  setSampleSize(samples) {
+    this.sampleSize = samples;
+
+    return this;
   }
 
   // Call to increment count (+1)
   incrementCount() {
     this.addCount(1);
+
+    return this;
   }
 
   // Call to decrement count (-1)
   decrementCount() {
     this.subtractCount(1);
+
+    return this;
   }
 
   // Increase count
   addCount(value) {
-    this.count += value;
+    this._count += value;
+    this._checkSampling();
+
+    return this;
   }
 
   // Decrease count
   subtractCount(value) {
-    this.count -= value;
+    this._count -= value;
+    this._checkSampling();
+
+    return this;
   }
 
   // Add an abritrary timing and bump the count
   addTime(time) {
-    this.time += time;
-    this.lastTiming = time;
-    this.count++;
+    this._time += time;
+    this._lastTiming = time;
+    this._count++;
+    this._checkSampling();
+
+    return this;
   }
 
   // Start a timer
   timeStart() {
     this._startTime = getHiResTimestamp();
     this._timerPending = true;
+
+    return this;
   }
 
   // End a timer. Adds to time and bumps the timing count.
   timeEnd() {
     if (!this._timerPending) {
-      return;
+      return this;
     }
 
     this.addTime(getHiResTimestamp() - this._startTime);
     this._timerPending = false;
+    this._checkSampling();
+
+    return this;
+  }
+
+  // Calculate average time / count for the previous window
+  getSampleAverageTime() {
+    return this.lastSampleCount > 0 ? this.lastSampleTime / this.lastSampleCount : 0;
+  }
+
+  // Calculate counts per second for the previous window
+  getSampleHz() {
+    return this.lastSampleTime > 0 ? this.lastSampleCount / (this.lastSampleTime / 1000) : 0;
   }
 
   // Calculate average time / count
@@ -63,7 +98,22 @@ export default class Stat {
     this.time = 0;
     this.count = 0;
     this.lastTiming = 0;
+    this._time = 0;
+    this._count = 0;
     this._startTime = 0;
     this._timerPending = false;
+
+    return this;
+  }
+
+  _checkSampling() {
+    if (this._count === this.sampleSize) {
+      this.lastSampleCount = this._count;
+      this.lastSampleTime = this._time;
+      this.count += this._count;
+      this.time += this._time;
+      this._time = 0;
+      this._count = 0;
+    }
   }
 }

--- a/test/modules/core/lib/stats.spec.js
+++ b/test/modules/core/lib/stats.spec.js
@@ -46,3 +46,23 @@ test('Stats#reset()', t => {
   t.equals(stat.time, 0, 'stat reset OK');
   t.end();
 });
+
+test.only('Stats#sampleSize()', t => {
+  const stats = new Stats({id: 'test'});
+  const stat = stats.get('test').setSampleSize(3);
+  stat.incrementCount();
+  stat.addTime(1);
+  t.equals(stat.count, 0, 'don\'t update count before sampling done');
+  t.equals(stat.time, 0, 'don\'t update time before sampling done');
+  stat.addTime(1);
+  t.equals(stat.count, 3, 'update count after sampling done');
+  t.equals(stat.time, 2, 'update time after sampling done');
+  stat.addTime(1);
+  stat.addTime(1);
+  stat.addTime(1);
+  t.equals(stat.lastSampleCount, 3, 'sampleCount only tracks last sampling');
+  t.equals(stat.lastSampleTime, 3, 'sampleTime only tracks last sampling');
+  t.equals(stat.count, 6, 'count tracks entire history');
+  t.equals(stat.time, 5, 'time tracks entire history');
+  t.end();
+});

--- a/test/modules/core/lib/stats.spec.js
+++ b/test/modules/core/lib/stats.spec.js
@@ -27,7 +27,7 @@ test('Stats#timer()', t => {
   t.doesNotThrow(() => timer.addTime(10), 'timer.addTime works');
   t.doesNotThrow(() => timer.getAverageTime(), 'timer.getAverageTime works');
   t.doesNotThrow(() => timer.getHz(), 'timer.getHz works');
-  t.equals(timer.count, 2, 'timer counts');
+  t.equals(timer.samples, 2, 'timer udpates samples');
   t.ok(timer.time > 0, 'timer times');
   t.ok(timer.getAverageTime() > 0, 'timer averages');
   t.ok(timer.getHz() > 0, 'timer calculates hz');
@@ -39,7 +39,7 @@ test('Stats#reset()', t => {
   const stat = stats.get('test');
   stat.incrementCount();
   stat.addTime(1);
-  t.equals(stat.count, 2, 'stat setup OK');
+  t.equals(stat.count, 1, 'stat setup OK');
   t.equals(stat.time, 1, 'stat setup OK');
   stats.reset();
   t.equals(stat.count, 0, 'stat reset OK');
@@ -47,22 +47,34 @@ test('Stats#reset()', t => {
   t.end();
 });
 
-test.only('Stats#sampleSize()', t => {
+test('Stats#timing sampleSize', t => {
+  const stats = new Stats({id: 'test'});
+  const stat = stats.get('test').setSampleSize(3);
+  stat.addTime(1);
+  stat.addTime(1);
+  t.equals(stat.time, 0, 'don\'t update time before sampling done');
+  stat.addTime(1);
+  t.equals(stat.time, 3, 'update time after sampling done');
+  stat.addTime(1);
+  stat.addTime(1);
+  stat.addTime(1);
+  t.equals(stat.lastSampleTime, 3, 'lastSampleTime only tracks last sampling');
+  t.equals(stat.time, 6, 'time tracks entire history');
+  t.end();
+});
+
+test('Stats#timing sampleSize', t => {
   const stats = new Stats({id: 'test'});
   const stat = stats.get('test').setSampleSize(3);
   stat.incrementCount();
-  stat.addTime(1);
+  stat.incrementCount();
   t.equals(stat.count, 0, 'don\'t update count before sampling done');
-  t.equals(stat.time, 0, 'don\'t update time before sampling done');
-  stat.addTime(1);
+  stat.incrementCount();
   t.equals(stat.count, 3, 'update count after sampling done');
-  t.equals(stat.time, 2, 'update time after sampling done');
-  stat.addTime(1);
-  stat.addTime(1);
-  stat.addTime(1);
-  t.equals(stat.lastSampleCount, 3, 'sampleCount only tracks last sampling');
-  t.equals(stat.lastSampleTime, 3, 'sampleTime only tracks last sampling');
+  stat.incrementCount();
+  stat.incrementCount();
+  stat.incrementCount();
+  t.equals(stat.lastSampleCount, 3, 'lastSampleCount only tracks last sampling');
   t.equals(stat.count, 6, 'count tracks entire history');
-  t.equals(stat.time, 5, 'time tracks entire history');
   t.end();
 });


### PR DESCRIPTION
Update `Stat` class to be able to track a "sample window". Also separate `samples` from `count` to allow for similar tracking of count metrics. New methods:
- `setSampleSize`: set the size of the sample window
- `getAverageCount`: get average count/sample over all samples
- `getSampleAverageTime`: get average time/sample in the last sample window
- `getSampleAverageCount`: get average count/sample in the last sample window
- `getSampleHz`: get average number of samples/second in the last sample window