### PR TITLE
Fix stat object typo lastTiming

### DIFF
--- a/modules/core/src/lib/stat.js
+++ b/modules/core/src/lib/stat.js
@@ -46,10 +46,10 @@ export default class Stat {
     return this;
   }
 
-  // Add an abritrary timing and bump the count
+  // Add an arbitrary timing and bump the count
   addTime(time) {
     this._time += time;
-    this._lastTiming = time;
+    this.lastTiming = time;
     this._samples++;
     this._checkSampling();
 

--- a/modules/core/test/lib/stats.spec.js
+++ b/modules/core/test/lib/stats.spec.js
@@ -41,25 +41,31 @@ test('Stats#reset()', t => {
   stat.addTime(1);
   t.equals(stat.count, 1, 'stat setup OK');
   t.equals(stat.time, 1, 'stat setup OK');
+  t.equals(stat.lastTiming, 1, 'stat setup OK');
   stats.reset();
   t.equals(stat.count, 0, 'stat reset OK');
   t.equals(stat.time, 0, 'stat reset OK');
+  t.equals(stat.lastTiming, 0, 'stat setup OK');
   t.end();
 });
 
 test('Stats#timing sampleSize', t => {
   const stats = new Stats({id: 'test'});
   const stat = stats.get('test').setSampleSize(3);
-  stat.addTime(1);
-  stat.addTime(1);
+  stat.addTime(0);
+  stat.addTime(2);
   t.equals(stat.time, 0, "don't update time before sampling done");
+  t.equals(stat.lastTiming, 2, 'always update lastTiming');
   stat.addTime(1);
   t.equals(stat.time, 3, 'update time after sampling done');
+  t.equals(stat.lastTiming, 1, 'always aupdate lastTiming');
   stat.addTime(1);
-  stat.addTime(1);
-  stat.addTime(1);
+  stat.addTime(0);
+  stat.addTime(2);
+
   t.equals(stat.lastSampleTime, 3, 'lastSampleTime only tracks last sampling');
   t.equals(stat.time, 6, 'time tracks entire history');
+  t.equals(stat.lastTiming, 2, 'always aupdate lastTiming');
   t.end();
 });
 


### PR DESCRIPTION
For https://github.com/uber/deck.gl/issues/3633

fix typo when updating `lastTiming`