### PR TITLE
Remove rest parameters from Log class

### DIFF
--- a/modules/core/src/lib/log.js
+++ b/modules/core/src/lib/log.js
@@ -373,10 +373,14 @@ function normalizePriority(priority) {
 export function normalizeArguments(opts) {
   const {priority, message} = opts;
   opts.priority = normalizePriority(priority);
-  // args should only contain arguments that appear after `message`
-  // not using rest parameters (...args) syntax to defeat perf hit in transpiled code
+  // We use `arguments` instead of rest parameters (...args) because IE
+  // does not support the syntax. Rest parameters is transpiled to code with
+  // perf impact. Doing it here instead avoids constructing args when logging is
+  // disabled.
+  // TODO - remove when/if IE support is dropped
   const args = opts.args ? Array.from(opts.args) : [];
   /* eslint-disable no-empty */
+  // args should only contain arguments that appear after `message`
   while (args.length && args.shift() !== message) {}
   /* eslint-enable no-empty */
   opts.args = args;

--- a/modules/core/src/lib/log.js
+++ b/modules/core/src/lib/log.js
@@ -156,13 +156,13 @@ export default class Log {
   }
 
   // Warn, but only once, no console flooding
-  warn(message, ...args) {
-    return this._getLogFunction(0, message, originalConsole.warn, args, ONCE);
+  warn(message) {
+    return this._getLogFunction(0, message, originalConsole.warn, arguments, ONCE);
   }
 
   // Print an error
-  error(message, ...args) {
-    return this._getLogFunction(0, message, originalConsole.error, args);
+  error(message) {
+    return this._getLogFunction(0, message, originalConsole.error, arguments);
   }
 
   deprecated(oldUsage, newUsage) {
@@ -177,30 +177,30 @@ in a later version. Use \`${newUsage}\` instead`);
   // Conditional logging
 
   // Log to a group
-  probe(priority, message, ...args) {
-    return this._getLogFunction(priority, message, originalConsole.log, args, {
+  probe(priority, message) {
+    return this._getLogFunction(priority, message, originalConsole.log, arguments, {
       time: true,
       once: true
     });
   }
 
   // Log a debug message
-  log(priority, message, ...args) {
-    return this._getLogFunction(priority, message, originalConsole.debug, args);
+  log(priority, message) {
+    return this._getLogFunction(priority, message, originalConsole.debug, arguments);
   }
 
   // Log a normal message
-  info(priority, message, ...args) {
-    return this._getLogFunction(priority, message, console.info, args);
+  info(priority, message) {
+    return this._getLogFunction(priority, message, console.info, arguments);
   }
 
   // Log a normal message, but only once, no console flooding
-  once(priority, message, ...args) {
+  once(priority, message) {
     return this._getLogFunction(
       priority,
       message,
       originalConsole.debug || originalConsole.info,
-      args,
+      arguments,
       ONCE
     );
   }
@@ -373,8 +373,12 @@ function normalizePriority(priority) {
 export function normalizeArguments(opts) {
   const {priority, message} = opts;
   opts.priority = normalizePriority(priority);
-
-  const args = opts.args || [];
+  // args should only contain arguments that appear after `message`
+  // not using rest parameters (...args) syntax to defeat perf hit in transpiled code
+  const args = opts.args ? Array.from(opts.args) : [];
+  /* eslint-disable no-empty */
+  while (args.length && args.shift() !== message) {}
+  /* eslint-enable no-empty */
   opts.args = args;
 
   switch (typeof priority) {

--- a/modules/core/test/lib/log.spec.js
+++ b/modules/core/test/lib/log.spec.js
@@ -3,7 +3,9 @@ import Probe, {Log} from 'probe.gl';
 import {normalizeArguments} from 'probe.gl/lib/log';
 import test from 'tape-catch';
 
-const makeOpts = (priority, message, ...args) => ({priority, message, args});
+function makeOpts(priority, message) {
+  return {priority, message, args: arguments};
+}
 
 const NORMALIZE_ARGUMENTS_TEST_CASES = [
   {
@@ -69,8 +71,8 @@ test('Probe#getTotal()', t => {
 test('Log#log', t => {
   const log = new Log({id: 'test'});
   t.ok(log instanceof Log, 'log created successfully');
-  t.doesNotThrow(() => log.log('test'), 'log.log works');
-  t.doesNotThrow(() => log.log(0, 'test'), 'log.log works');
+  t.doesNotThrow(() => log.log('test')(), 'log.log works');
+  t.doesNotThrow(() => log.log(0, 'test')(), 'log.log works');
   t.end();
 });
 


### PR DESCRIPTION
The rest parameters syntax is not supported in IE.

After transpilation, it looks like this:  https://unpkg.com/browse/probe.gl@3.1.1/dist/es6/lib/log.js#L138

This operation is performed regardless of whether logging is enabled.

This PR moves the construction of `args` array into `normalizeArguments`.