### PR TITLE
Change default `enabled` behavior of Log class

### DIFF
--- a/docs/api-reference/log/log.md
+++ b/docs/api-reference/log/log.md
@@ -82,7 +82,7 @@ Creates a new `Log` instance.
 
 `log.enable(false)`
 
-Accepts one argument `true` or `false`.
+Accepts one argument `true` or `false`. When disabled, calling log methods do not print anything to the console.
 
 ### getLevel
 

--- a/modules/core/src/lib/log.js
+++ b/modules/core/src/lib/log.js
@@ -41,7 +41,7 @@ const originalConsole = {
 };
 
 const DEFAULT_SETTINGS = {
-  enabled: false,
+  enabled: true,
   level: 0
 };
 
@@ -305,8 +305,7 @@ in a later version. Use \`${newUsage}\` instead`);
   // PRIVATE METHODS
 
   _shouldLog(logLevel) {
-    logLevel = normalizeLogLevel(logLevel);
-    return logLevel === 0 || (this.isEnabled() && this.getLevel() >= logLevel);
+    return this.isEnabled() && this.getLevel() >= normalizeLogLevel(logLevel);
   }
 
   _getLogFunction(logLevel, message, method, args = [], opts) {


### PR DESCRIPTION
- If log is disabled, all levels of logging are expected to be blocked. Currently it doesn't block L0 including warnings, errors and level=0 logs. The `enabled` flag is practically meaningless (can just be replaced with `log.level = 0`).
- It's reasonable to expect that `new Log().log('hello')()` would actually log something to the console. Currently log instances are disabled by default.
- It's cumbersome for the users to have to do `log.enable(true).setLevel(1)` just to see some logs.

In both deck.gl and luma.gl, the log objects are enabled on initialization, e.g. https://github.com/uber/deck.gl/blob/7.3-release/modules/core/src/utils/log.js#L3
Therefore changing the default here does not affect the default behavior in our primary use cases.