### PR TITLE
bench: Add `options.repetitions` to tests for more meaningful metrics reporting

### DIFF
--- a/docs/api-reference/bench/bench.md
+++ b/docs/api-reference/bench/bench.md
@@ -35,7 +35,6 @@ Adds a group header.
 Adds a test case. Supports multiple signatures:
 
 `bench.add(id : String, options : Object, testFunc: () => void)`
-`bench.add(priority : Number, id : String, testFunc: () => void)`
 `bench.add(id : String, testFunc: () => void)`
 
 Parameters

--- a/docs/api-reference/bench/bench.md
+++ b/docs/api-reference/bench/bench.md
@@ -34,10 +34,8 @@ Adds a group header.
 
 Adds a test case. Supports multiple signatures:
 
-`bench.add(id : String, options : Object, initFunc: () => void, testFunc: () => void)`
-`bench.add(priority : Number, id : String, initFunc: () => void, testFunc: () => void)`
+`bench.add(id : String, options : Object, testFunc: () => void)`
 `bench.add(priority : Number, id : String, testFunc: () => void)`
-`bench.add(id : String, initFunc: () => void, testFunc: () => void)`
 `bench.add(id : String, testFunc: () => void)`
 
 Parameters
@@ -45,10 +43,11 @@ Parameters
 * `priority`=`0` (Number, optional) - allows controlling which bench cases execute. Can also be specified through the `options` object.
 * `id` (String) - The unique string for this test. Used as the description of the test in the results.
 * `initFunc` (Function, options) - Function run before any tests
-* `testFunc` (Function, options) - Function run for each test iteration
+* `testFunc` (Function, options) - Function run for each test iteration. 
 
 Options
 
+* `initialize`: `() => any` initialization function called once before `testFunc` iterations start.
 * `repetitions` multiplier applied to the number of actual repetitions. Use this if each test case already performs a number of iterations
 * `priority` can be specified as part of options
 

--- a/docs/api-reference/bench/bench.md
+++ b/docs/api-reference/bench/bench.md
@@ -32,21 +32,33 @@ Adds a group header.
 
 ### add
 
-Adds a test case. Supports multiple signatures
+Adds a test case. Supports multiple signatures:
 
-`bench.add(priority, id, initFunc, testFunc)`
-`bench.add(priority, id, testFunc)`
-`bench.add(id, initFunc, testFunc)`
-`bench.add(id, testFunc)`
+`bench.add(id : String, options : Object, initFunc: () => void, testFunc: () => void)`
+`bench.add(priority : Number, id : String, initFunc: () => void, testFunc: () => void)`
+`bench.add(priority : Number, id : String, testFunc: () => void)`
+`bench.add(id : String, initFunc: () => void, testFunc: () => void)`
+`bench.add(id : String, testFunc: () => void)`
 
-* `priority`=`0` (Number, optional) - allows controlling which bench cases execute.
-* `id` (String)
-* `initFunc` (Function, options) -
-* `testFunc` (Function, options) -
+Parameters
+
+* `priority`=`0` (Number, optional) - allows controlling which bench cases execute. Can also be specified through the `options` object.
+* `id` (String) - The unique string for this test. Used as the description of the test in the results.
+* `initFunc` (Function, options) - Function run before any tests
+* `testFunc` (Function, options) - Function run for each test iteration
+
+Options
+
+* `repetitions` multiplier applied to the number of actual repetitions. Use this if each test case already performs a number of iterations
+* `priority` can be specified as part of options
+
+Returns itself for chaining.
 
 ## addAsync
 
-Adds an async test case. Use when `testFunc` returns a promise. Supports same signatures as `add`.
+Adds an async test case. Use when `testFunc` returns a promise. Supports same signatures as `add`. 
+
+When using `addAsync`, `testFunc` is expected to return a promise.
 
 ### run()
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,8 +1,29 @@
 # What's New
 
+## v3.x 
+
+Release Date: TBD
+
+### **@probe.gl/bench**
+- New bench case option: `repetitions`
+
+## v3.2
+
+Release Date: Dec 16, 2019
+
+New modules
+- `@probe.gl/stats` New module enabling users to import `Stats` object only
+- `@probe.gl/seer` Seer repository moved into probe.gl monorepo.
+
+`@probe.gl/log`: `Log` class improvements
+- Rename `log.priority` to `log.level`
+- Change default `enabled` behavior of Log class
+- Improve log perf
+- Remove rest parameters from Log class
+
 ## v3.1
 
-Release Date: TBD, Sep 2019 (Beta Release Available)
+Release Date: Sep 13, 2019
 
 ### **probe.gl**
 
@@ -20,7 +41,7 @@ Release Date: TBD, Sep 2019 (Beta Release Available)
 
 ## v3.0
 
-Release Date: Apr, 2019
+Release Date: Apr 1, 2019
 
 ## Module split
 

--- a/modules/bench/src/bench.js
+++ b/modules/bench/src/bench.js
@@ -106,15 +106,19 @@ export default class Bench {
   }
 
   // Signatures:
-  //  add(priority, id, testFunc)
   //  add(id, {...options}, testFunc)
   //  add(id, testFunc)
   // Deprecated signatures
+  //  add(priority, id, testFunc)
   //  add(priority, id, initFunc, testFunc)
   //  add(id, initFunc, testFunc)
 
   _add(priority, id, func1, func2) {
     let options = {};
+
+    if (typeof priority === 'number') {
+      console.warn('`priority` argument is deprecated, use `options.priority` instead');
+    }
 
     if (typeof priority === 'string' && typeof id === 'object') {
       options = id;

--- a/modules/bench/src/bench.js
+++ b/modules/bench/src/bench.js
@@ -60,11 +60,6 @@ export default class Bench {
     return this;
   }
 
-  // Signatures:
-  // add(priority, id, initFunc, testFunc)
-  // add(priority, id, testFunc)
-  // add(id, initFunc, testFunc)
-  // add(id, testFunc)
   add(priority, id, func1, func2) {
     this._add(priority, id, func1, func2);
     return this;
@@ -110,8 +105,20 @@ export default class Bench {
     return current;
   }
 
+  // Signatures:
+  // add(priority, id, initFunc, testFunc)
+  // add(priority, id, testFunc)
+  // add({id, {...options}, initFunc, testFunc)
+  // add(id, initFunc, testFunc)
+  // add(id, testFunc)
   _add(priority, id, func1, func2) {
-    if (typeof priority === 'string') {
+    let options = {};
+
+    if (typeof priority === 'string' && typeof id === 'object') {
+      options = id;
+      id = priority;
+      priority = 0;
+    } else if (typeof priority === 'string') {
       func2 = func1;
       func1 = id;
       id = priority;
@@ -130,7 +137,9 @@ export default class Bench {
 
     // Test case options
     const opts = {
-      ...this.opts
+      ...this.opts,
+      repetitions: 1, // repetitions per test case
+      ...options
     };
 
     assert(!this.tests[id], 'tests need unique id strings');
@@ -267,7 +276,8 @@ async function runBenchTestTimedAsync(test, minTime) {
 
   return {
     time,
-    iterations
+    // Test cases can use `options.repetitions` to account for multiple repetitions per iteration
+    iterations: iterations * test.opts.repetitions
   };
 }
 

--- a/modules/bench/src/bench.js
+++ b/modules/bench/src/bench.js
@@ -106,11 +106,13 @@ export default class Bench {
   }
 
   // Signatures:
-  // add(priority, id, initFunc, testFunc)
-  // add(priority, id, testFunc)
-  // add({id, {...options}, initFunc, testFunc)
-  // add(id, initFunc, testFunc)
-  // add(id, testFunc)
+  //  add(priority, id, testFunc)
+  //  add(id, {...options}, testFunc)
+  //  add(id, testFunc)
+  // Deprecated signatures
+  //  add(priority, id, initFunc, testFunc)
+  //  add(id, initFunc, testFunc)
+
   _add(priority, id, func1, func2) {
     let options = {};
 
@@ -128,9 +130,10 @@ export default class Bench {
     assert(typeof id === 'string');
     assert(typeof func1 === 'function');
 
-    let initFunc = null;
+    let initFunc = options.initialize;
     let testFunc = func1;
     if (typeof func2 === 'function') {
+      console.warn('`initFunc` argument is deprecated, use `options.initialize` instead');
       initFunc = func1;
       testFunc = func2;
     }

--- a/modules/bench/src/format-utils.js
+++ b/modules/bench/src/format-utils.js
@@ -7,7 +7,18 @@ export function formatSI(number, precision = 3) {
 }
 
 function getSISuffix(multipleOf3) {
-  const SI_SUFFIXES = {0: '', 1: 'K', 2: 'M', 3: 'G', '-1': 'm', '-2': 'µ', '-3': 'n'};
+  const SI_SUFFIXES = {
+    0: '',
+    1: 'K',
+    2: 'M',
+    3: 'G',
+    4: 'T',
+    5: 'P',
+    6: 'E',
+    '-1': 'm',
+    '-2': 'µ',
+    '-3': 'n'
+  };
   const key = String(multipleOf3);
   return key in SI_SUFFIXES ? SI_SUFFIXES[key] : `e${multipleOf3 * 3}`;
 }

--- a/modules/bench/test/bench.spec.js
+++ b/modules/bench/test/bench.spec.js
@@ -21,6 +21,22 @@ test('Bench#run', t => {
     log: ({message}) => t.comment(message)
   });
 
+  suite.add('initFunc in options', {initialize: () => 1}, value => {
+    if (!value === 1) {
+      t.fail();
+    }
+  });
+
+  suite.add(
+    'initFunc as param (deprecated)',
+    () => 1,
+    value => {
+      if (!value === 1) {
+        t.fail();
+      }
+    }
+  );
+
   iteratorBench(suite);
   parseColorBench(suite);
 

--- a/modules/bench/test/iterator.bench.js
+++ b/modules/bench/test/iterator.bench.js
@@ -17,29 +17,28 @@ async function* asyncIterator(length) {
 export default function coreBench(bench) {
   return bench
     .group('Core Module - Async Iteration')
-
-    .add('for (let i=0; ...)x1M', () => {
+    .add('for (let i=0; ...)', {repetitions: LENGTH}, () => {
       let sum = 0;
       for (let i = 0; i < LENGTH; i++) {
         sum += i;
       }
       return sum;
     })
-    .add('for (const element of ARRAY)x1M', () => {
+    .add('for (const element of ARRAY)', {repetitions: LENGTH}, () => {
       let sum = 0;
       for (const element of ARRAY) {
         sum += element;
       }
       return sum;
     })
-    .add('for (const element of iterator)x1M', () => {
+    .add('for (const element of iterator)', {repetitions: LENGTH}, () => {
       let sum = 0;
       for (const element of iterator(LENGTH)) {
         sum += element;
       }
       return sum;
     })
-    .addAsync('for await (const element of asyncIterator)x1M', async () => {
+    .addAsync('for await (const element of asyncIterator)', {repetitions: LENGTH}, async () => {
       let sum = 0;
       for await (const element of asyncIterator(ARRAY)) {
         sum += element;

--- a/modules/bench/test/parse-color.bench.js
+++ b/modules/bench/test/parse-color.bench.js
@@ -14,57 +14,48 @@ export default function benchColor(suite) {
     .group('Parse Color: from color array, write into target array')
     .add(
       'color#parseColor (3 element array) -> Uint8ClampedArray target',
-      () => new Uint8ClampedArray(4),
+      {initialize: () => new Uint8ClampedArray(4)},
       target => parseColor(COLOR_ARRAY_4, target)
     )
     .add(
-      1,
       'color#parseColor (3 element typed array) -> Uint8ClampedArray target',
-      () => new Uint8ClampedArray(4),
+      {priority: 1, initialize: () => new Uint8ClampedArray(4)},
       target => parseColor(COLOR_TYPED_ARRAY, target)
     )
     .add(
-      1,
       'color#parseColor (4 element typed array) -> Uint8ClampedArray target',
-      () => new Uint8ClampedArray(4),
+      {priority: 1, initialize: () => new Uint8ClampedArray(4)},
       target => parseColor(COLOR_TYPED_ARRAY_4, target)
     )
 
     .add(
-      1,
       'color#parseColor (3 element array) -> array target',
-      () => [],
+      {priority: 1, initialize: () => []},
       target => parseColor(COLOR_ARRAY, target)
     )
     .add(
-      1,
       'color#parseColor (4 element array) -> array target',
-      () => [],
+      {priority: 1, initialize: () => []},
       target => parseColor(COLOR_ARRAY_4, target)
     )
 
     .group('Parse Color: From string')
     .add(
       'color#parseColor (string) -> typed array target',
-      () => new Uint8ClampedArray(4),
+      {initialize: () => new Uint8ClampedArray(4)},
       target => parseColor(COLOR_STRING, target)
     )
     .add(
-      1,
       'color#parseColor (string with alpha) -> typed array target',
-      () => new Uint8ClampedArray(4),
+      {priority: 1, initialize: () => new Uint8ClampedArray(4)},
       target => parseColor(COLOR_STRING_4, target)
     )
-    .add(
-      1,
-      'color#parseColor (string) -> array target',
-      () => [],
-      target => parseColor(COLOR_STRING, target)
+    .add('color#parseColor (string) -> array target', {priority: 1, initialize: () => []}, target =>
+      parseColor(COLOR_STRING, target)
     )
     .add(
-      1,
       'color#parseColor (string with alpha) -> array target',
-      () => [],
+      {priority: 1, initialize: () => []},
       target => parseColor(COLOR_STRING_4, target)
     )
     .add(1, 'color#parseColor (string), no target', () => parseColor(COLOR_STRING))


### PR DESCRIPTION
When measuring e.g. iteration speed, the actual number of iterations is a multiple of the reported number.

The addition of this options allows the reporting to reflect the real number of iterations, making different results more meaningful and comparable:

```
    const LENGTH = 1e6;
    bench.add('for (let i=0; ...)', {repetitions: LENGTH}, () => {
      let sum = 0;
      for (let i = 0; i < LENGTH; i++) {
        sum += i;
      }
      return sum;
    })
```
