### PR TITLE
[test-utils] Add polyfill

### DIFF
--- a/docs/api-reference/test-utils/browser-test-driver.md
+++ b/docs/api-reference/test-utils/browser-test-driver.md
@@ -30,6 +30,8 @@ new BrowserTestDriver().run({
 In your script that is run on the browser:
 
 ```js
+// Polyfill so that the bundle can execute in browsers not controlled by puppeteer
+require('@probe.gl/test-utils/polyfill');
 // Run test cases
 ...
 // App is done running, terminate the browser instance

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -16,7 +16,8 @@
   "esnext": "dist/es6/index.js",
   "files": [
     "dist",
-    "src"
+    "src",
+    "polyfill.js"
   ],
   "browser": {
     "child_process": false,

--- a/modules/test-utils/polyfill.js
+++ b/modules/test-utils/polyfill.js
@@ -27,7 +27,6 @@ function captureAndDiffScreen() {
   });
 }
 
-/* global window */
 if (!window.browserTestDriver_finish) {
   window.browserTestDriver_fail = noOp;
   window.browserTestDriver_finish = noOp;

--- a/modules/test-utils/polyfill.js
+++ b/modules/test-utils/polyfill.js
@@ -1,0 +1,37 @@
+// Polyfill for non-puppeteer environments
+// so that test bundle can run in other browsers
+
+// A puppeteer injected method returns a promise
+function noOp() {
+  return Promise.resolve();
+}
+
+function isHeadless() {
+  return Promise.resolve(false);
+}
+
+function emulateInput() {
+  // eslint-disable-next-line
+  console.error('BrowserTestDriver: emulateInput is not available');
+  return Promise.resolve();
+}
+
+function captureAndDiffScreen() {
+  // eslint-disable-next-line
+  console.error('BrowserTestDriver: emulateInput is not available');
+  return Promise.resolve({
+    headless: false,
+    match: 0,
+    matchPercentage: 'N/A',
+    success: true
+  });
+}
+
+/* global window */
+if (!window.browserTestDriver_finish) {
+  window.browserTestDriver_fail = noOp;
+  window.browserTestDriver_finish = noOp;
+  window.browserTestDriver_isHeadless = isHeadless;
+  window.browserTestDriver_emulateInput = emulateInput;
+  window.browserTestDriver_captureAndDiffScreen = captureAndDiffScreen;
+}


### PR DESCRIPTION
`require('@probe.gl/test-utils/polyfill');` in the client script allows it to run in non-puppeteer environments.