### PR TITLE
Remove isHeadless from polyfill

### DIFF
--- a/modules/test-utils/polyfill.js
+++ b/modules/test-utils/polyfill.js
@@ -6,10 +6,6 @@ function noOp() {
   return Promise.resolve();
 }
 
-function isHeadless() {
-  return Promise.resolve(false);
-}
-
 function emulateInput() {
   // eslint-disable-next-line
   console.error('BrowserTestDriver: emulateInput is not available');
@@ -30,7 +26,6 @@ function captureAndDiffScreen() {
 if (!window.browserTestDriver_finish) {
   window.browserTestDriver_fail = noOp;
   window.browserTestDriver_finish = noOp;
-  window.browserTestDriver_isHeadless = isHeadless;
   window.browserTestDriver_emulateInput = emulateInput;
   window.browserTestDriver_captureAndDiffScreen = captureAndDiffScreen;
 }


### PR DESCRIPTION
`browserTestDriver_isHeadless` should only be present in the headless mode.