### PR TITLE
Fix Stats.getTable type

### DIFF
--- a/modules/stats/src/lib/stats.d.ts
+++ b/modules/stats/src/lib/stats.d.ts
@@ -15,9 +15,11 @@ export default class Stats {
   forEach(fn: (stat: Stat) => void): void;
 
   getTable(): {
-    time: number;
-    count: number;
-    average: number;
-    hz: number;
-  }[];
+    [name: string]: {
+      time: number;
+      count: number;
+      average: number;
+      hz: number;
+    }
+  };
 }


### PR DESCRIPTION
Type does not match implementation. It is actually an object containing string keys.