### PR TITLE
Stats widget: Header should have `pointer` cursor

### DIFF
--- a/modules/stats-widget/src/stats-widget.ts
+++ b/modules/stats-widget/src/stats-widget.ts
@@ -15,7 +15,8 @@ const DEFAULT_CSS = {
     lineSpacing: 6
   },
   headerCSS: {
-    fontSize: '16px'
+    fontSize: '16px',
+    cursor: 'pointer'
   },
   itemCSS: {
     paddingLeft: '8px'


### PR DESCRIPTION
Indicates the header is an interactable (collapse/uncollapse) element.