### PR TITLE
feat(log): More robust typings for log.assert.

### DIFF
--- a/modules/log/src/log.ts
+++ b/modules/log/src/log.ts
@@ -138,7 +138,7 @@ export default class Log {
 
   // Unconditional logging
 
-  assert(condition: unknown, message?: string): void {
+  assert(condition: unknown, message?: string): asserts condition {
     assert(condition, message);
   }
 

--- a/modules/log/src/utils/assert.ts
+++ b/modules/log/src/utils/assert.ts
@@ -1,4 +1,4 @@
-export default function assert(condition: unknown, message?: string) {
+export default function assert(condition: unknown, message?: string): asserts condition {
   if (!condition) {
     throw new Error(message || 'Assertion failed');
   }


### PR DESCRIPTION
Use [special syntax](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions) for `Log.assert` so Typescript can properly deduce type of variable if `assert` doesn't throw.

See this discussion: https://github.com/visgl/deck.gl/pull/6659#discussion_r810002439