### PR TITLE
fix(log): vite build error re nodeAsciifyImage

### DIFF
--- a/modules/log/src/log.ts
+++ b/modules/log/src/log.ts
@@ -8,7 +8,7 @@ import {addColor} from './utils/color';
 import {autobind} from './utils/autobind';
 import assert from './utils/assert';
 import {getHiResTimestamp} from './utils/hi-res-timestamp';
-import {nodeAsciifyImage} from './node/node-asciify-image';
+import nodeAsciifyImage from './node/node-asciify-image';
 
 // Instrumentation in other packages may override console methods, so preserve them here
 const originalConsole = {

--- a/modules/log/src/node/node-asciify-image.ts
+++ b/modules/log/src/node/node-asciify-image.ts
@@ -4,7 +4,7 @@
 // browser statement. https://github.com/uber-web/probe.gl/issues/196
 
 /** Use the asciify-image module, if installed, to log an image under node.js */
-export function nodeAsciifyImage({image, message = '', scale = 1}): () => Promise<void> {
+export default function nodeAsciifyImage({image, message = '', scale = 1}): () => Promise<void> {
   // Note: Runtime load of the "asciify-image" module, avoids including in browser bundles
   let asciify = null;
   try {


### PR DESCRIPTION
For #196, vite build error with v3.5.1

`Error: 'nodeAsciifyImage' is not exported by __vite-browser-external, imported by node_modules/@probe.gl/log/dist/esm/log.js`