### PR TITLE
Fix StatsWidget test

### DIFF
--- a/modules/stats-widget/src/stats-widget.ts
+++ b/modules/stats-widget/src/stats-widget.ts
@@ -168,17 +168,16 @@ export default class StatsWidget {
 
     // the widget is contained in a <div>
     if (!this._container) {
-      this._container = document.createElement('div');
-      for (const name in this._css) {
-        this._container.style[name] = this._css[name];
-      }
-      document.body.appendChild(this._container);
+      this._container = document.body;
     }
 
     // When adding the widget to an existing element, make sure there
     // is a container for this widget specifically, so that multiple widgets
     // can be added to the same container.
     this._innerContainer = document.createElement('div');
+    for (const name in this._css) {
+      this._innerContainer.style[name] = this._css[name];
+    }
     this._container.appendChild(this._innerContainer);
 
     // Create the contents of the stats widget, starting with the header

--- a/modules/stats-widget/test/stats-widget.spec.js
+++ b/modules/stats-widget/test/stats-widget.spec.js
@@ -34,14 +34,13 @@ test('StatsWidget#import', t => {
   t.end();
 });
 
-test.skip('StatsWidget#Constructor with no stats or options', t => {
+test('StatsWidget#Constructor with no stats or options', t => {
   const statsWidget = new StatsWidget(null);
   t.ok(statsWidget._container, 'Should create a dom container.');
   t.ok(statsWidget._header, 'Should create a dom header.');
-  t.equals(statsWidget._container.childNodes.length, 1, 'Should have one child node.');
   t.ok(
-    statsWidget._container.childNodes[0] === statsWidget._innerContainer,
-    'Should append inner container to container as the first child'
+    statsWidget._innerContainer.parentElement === statsWidget._container,
+    'Should append inner container to container'
   );
   t.ok(
     statsWidget._innerContainer.childNodes[0] === statsWidget._header,


### PR DESCRIPTION
Fix the following issues:

- StatsWidget permanently modifies the CSS styles of user-supplied container
- When no container is specified, StatsWidget creates a container that is not removed upon calling `remove()`

These cause render tests to fail because `StatsWidget` instances created during unit tests do not clean up after themselves.