### PR TITLE
chore: Enable all available typescript checks to selected modules

### DIFF
--- a/modules/bench/src/format-utils.ts
+++ b/modules/bench/src/format-utils.ts
@@ -20,7 +20,7 @@ function getSISuffix(multipleOf3: number): string {
     '-3': 'n'
   };
   const key = String(multipleOf3);
-  return key in SI_SUFFIXES ? SI_SUFFIXES[key] : `e${multipleOf3 * 3}`;
+  return key in SI_SUFFIXES ? SI_SUFFIXES[key] || '' : `e${multipleOf3 * 3}`;
 }
 
 // Breaks a number into a normalized base and an exponent

--- a/modules/bench/src/stat-utils.ts
+++ b/modules/bench/src/stat-utils.ts
@@ -6,16 +6,15 @@ export function mean(numbers: number[]): number {
 }
 
 /** standard deviation */
-export function std(numbers: number[], _mean?: number): number {
+export function std(numbers: number[], precalculatedMean?: number): number {
   if (numbers.length <= 1) {
     return 0;
   }
 
-  if (_mean === undefined) {
-    _mean = mean(numbers);
-  }
+  const meanValue = precalculatedMean === undefined ? mean(numbers) : precalculatedMean;
+
   return Math.sqrt(
-    numbers.reduce((d, x) => d + (x - _mean) * (x - _mean), 0) / (numbers.length - 1)
+    numbers.reduce((d, x) => d + (x - meanValue) * (x - meanValue), 0) / (numbers.length - 1)
   );
 }
 

--- a/modules/env/src/lib/get-browser.ts
+++ b/modules/env/src/lib/get-browser.ts
@@ -23,6 +23,7 @@
 
 import isBrowser from './is-browser';
 import isElectron from './is-electron';
+import {navigator} from './globals';
 
 declare global {
   var chrome: boolean; // eslint-disable-line no-var
@@ -50,9 +51,7 @@ export default function getBrowser(
     return 'Electron';
   }
 
-  const navigator_ = typeof navigator !== 'undefined' ? navigator : {};
-  // @ts-expect-error
-  const userAgent = mockUserAgent || navigator_.userAgent || '';
+  const userAgent = mockUserAgent || navigator.userAgent || '';
   // const appVersion = navigator_.appVersion || '';
 
   // NOTE: Order of tests matter, as many agents list Chrome etc.

--- a/modules/env/src/lib/globals.ts
+++ b/modules/env/src/lib/globals.ts
@@ -1,24 +1,10 @@
-/* eslint-disable no-restricted-globals */
-const globals = {
-  self: typeof self !== 'undefined' && self,
-  window: typeof window !== 'undefined' && window,
-  global: typeof global !== 'undefined' && global,
-  document: typeof document !== 'undefined' && document,
-  process: typeof process === 'object' && process
-};
-
-const global_ = globalThis;
-const self_ = globals.self || globals.window || globals.global;
-const window_ = globals.window || globals.self || globals.global;
-const document_ = globals.document || {};
-const process_ = globals.process || {};
-const console_ = console;
-
-export {
-  self_ as self,
-  window_ as window,
-  global_ as global,
-  document_ as document,
-  process_ as process,
-  console_ as console
-};
+export const global = globalThis;
+// eslint-disable-next-line consistent-this
+export const self = globalThis.self || globalThis.window || globalThis.global;
+export const window = (globalThis.window ||
+  globalThis.self ||
+  globalThis.global) as unknown as Window;
+export const document = globalThis.document || ({} as Document);
+export const process = globalThis.process || ({} as NodeJS.Process);
+export const console = globalThis.console;
+export const navigator = globalThis.navigator || ({} as Navigator);

--- a/modules/log/src/log.ts
+++ b/modules/log/src/log.ts
@@ -35,7 +35,7 @@ type Table = Record<string, any>;
 
 // Instrumentation in other packages may override console methods, so preserve them here
 const originalConsole = {
-  debug: isBrowser ? console.debug || console.log : console.log,
+  debug: isBrowser() ? console.debug || console.log : console.log,
   log: console.log,
   info: console.info,
   warn: console.warn,
@@ -220,10 +220,15 @@ in a later version. Use \`${newUsage}\` instead`);
   /** Logs an object as a table */
   table(logLevel, table?, columns?): LogFunction {
     if (table) {
-      // @ts-expect-error Not clear how this works, columns being passed as arguments
-      return this._getLogFunction(logLevel, table, console.table || noop, columns && [columns], {
-        tag: getTableHeader(table)
-      });
+      return this._getLogFunction(
+        logLevel,
+        table,
+        console.table || noop,
+        (columns && [columns]) as unknown as IArguments,
+        {
+          tag: getTableHeader(table)
+        }
+      );
     }
     return noop;
   }
@@ -245,7 +250,7 @@ in a later version. Use \`${newUsage}\` instead`);
     if (!this._shouldLog(logLevel || priority)) {
       return noop;
     }
-    return isBrowser
+    return isBrowser()
       ? logImageInBrowser({image, message, scale})
       : logImageInNode({image, message, scale});
   }
@@ -328,7 +333,7 @@ in a later version. Use \`${newUsage}\` instead`);
 
       const tag = opts.tag || opts.message;
 
-      if (opts.once) {
+      if (opts.once && tag) {
         if (!cache[tag]) {
           cache[tag] = getHiResTimestamp();
         } else {

--- a/modules/log/src/utils/hi-res-timestamp.ts
+++ b/modules/log/src/utils/hi-res-timestamp.ts
@@ -5,7 +5,7 @@ import {window, process, isBrowser} from '@probe.gl/env';
 /** Get best timer available. */
 export function getHiResTimestamp() {
   let timestamp;
-  if (isBrowser && 'performance' in window) {
+  if (isBrowser() && window.performance) {
     timestamp = window?.performance?.now?.();
   } else if ('hrtime' in process) {
     // @ts-ignore

--- a/modules/log/src/utils/local-storage.ts
+++ b/modules/log/src/utils/local-storage.ts
@@ -2,7 +2,7 @@
 
 export type StorageType = 'sessionStorage' | 'localStorage';
 
-function getStorage(type: StorageType): Storage {
+function getStorage(type: StorageType): Storage | null {
   try {
     const storage: Storage = window[type];
     const x = '__storage_test__';
@@ -16,7 +16,7 @@ function getStorage(type: StorageType): Storage {
 
 // Store keys in local storage via simple interface
 export class LocalStorage<Configuration extends {}> {
-  storage: Storage;
+  storage: Storage | null;
   id: string;
   config: Required<Configuration>;
 

--- a/modules/react-bench/tsconfig.json
+++ b/modules/react-bench/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "exactOptionalPropertyTypes": true,
     "composite": true,
     "rootDir": "src",
     "outDir": "dist"

--- a/modules/stats-widget/src/stats-widget.ts
+++ b/modules/stats-widget/src/stats-widget.ts
@@ -243,7 +243,7 @@ export default class StatsWidget {
   _getLines(stat: Stat): string[] {
     const formatter: StatFormatter =
       // eslint-disable-next-line
-      this._formatters[stat.name] || this._formatters[stat.type] || DEFAULT_COUNT_FORMATTER;
+      this._formatters[stat.name] || this._formatters[stat.type || ''] || DEFAULT_COUNT_FORMATTER;
     // const stat = this.stats.get(stat.name);
     return stat ? formatter(stat).split('\n') : [];
   }

--- a/modules/stats-widget/src/stats-widget.ts
+++ b/modules/stats-widget/src/stats-widget.ts
@@ -28,8 +28,10 @@ const DEFAULT_CSS = {
 
 export type StatFormatter = (stat: Stat) => string;
 
+const DEFAULT_COUNT_FORMATTER = stat => `${stat.name}: ${stat.count}`;
+
 export const DEFAULT_FORMATTERS: Record<string, StatFormatter> = {
-  count: stat => `${stat.name}: ${stat.count}`,
+  count: DEFAULT_COUNT_FORMATTER,
   averageTime: stat => `${stat.name}: ${formatTime(stat.getAverageTime())}`,
   totalTime: stat => `${stat.name}: ${formatTime(stat.time)}`,
   fps: stat => `${stat.name}: ${Math.round(stat.getHz())}fps`,
@@ -47,40 +49,40 @@ export type StatWidgetProps = {
 
 export default class StatsWidget {
   stats: Stats;
-  title: string;
+  title: string | undefined;
   collapsed: boolean = false;
   _framesPerUpdate: number;
   _formatters = DEFAULT_FORMATTERS;
   _css;
   _headerCSS;
   _itemCSS;
-  _container: HTMLElement | null = null;
-  _innerContainer: HTMLElement = null;
-  _statsContainer: HTMLElement = null;
-  _header: HTMLElement = null;
+  _container: HTMLElement = document.body;
+  _innerContainer: HTMLElement | null = null;
+  _statsContainer: HTMLElement | null = null;
+  _header: HTMLElement | null = null;
   _resetOnUpdate: Record<string, boolean> = {};
   _counter: number = 0;
   _items = {};
   _added: boolean = false;
 
-  constructor(stats: Stats, options?: StatWidgetProps) {
+  constructor(stats: Stats, props?: StatWidgetProps) {
     this.stats = stats;
-    this.title = options?.title;
+    this.title = props?.title;
 
-    this._framesPerUpdate = Math.round(Math.max(options?.framesPerUpdate || 1, 1));
+    this._framesPerUpdate = Math.round(Math.max(props?.framesPerUpdate || 1, 1));
 
-    this._initializeFormatters(options);
-    this._initializeUpdateConfigs(options);
+    this._initializeFormatters(props);
+    this._initializeUpdateConfigs(props);
 
     // UI
-    this._css = Object.assign({}, DEFAULT_CSS.css, options?.css);
+    this._css = Object.assign({}, DEFAULT_CSS.css, props?.css);
     this._headerCSS = Object.assign({}, DEFAULT_CSS.headerCSS, this._css.header);
     this._itemCSS = Object.assign({}, DEFAULT_CSS.itemCSS, this._css.item);
 
     delete this._css.header;
     delete this._css.item;
 
-    this._createDOM(options?.container);
+    this._createDOM(props?.container);
     this._createDOMStats();
   }
 
@@ -114,7 +116,9 @@ export default class StatsWidget {
   remove(): void {
     // if re-adding the stats widget is needed, a code path to
     // re-add the _innerContainer should be added, e.g. in _update.
-    this._container.removeChild(this._innerContainer);
+    if (this._innerContainer) {
+      this._container.removeChild(this._innerContainer);
+    }
   }
 
   setCollapsed(collapsed: boolean): void {
@@ -137,39 +141,36 @@ export default class StatsWidget {
     });
   }
 
-  _initializeFormatters(options?: StatWidgetProps): void {
-    if (options?.formatters) {
-      for (const name in options.formatters) {
-        let formatter = options.formatters[name];
+  _initializeFormatters(props?: StatWidgetProps): void {
+    if (props?.formatters) {
+      for (const name in props.formatters) {
+        let formatter = props.formatters[name];
 
         if (typeof formatter === 'string') {
           formatter = DEFAULT_FORMATTERS[formatter];
         }
 
-        this._formatters[name] = formatter;
+        if (formatter) {
+          this._formatters[name] = formatter;
+        }
       }
     }
   }
 
-  _initializeUpdateConfigs(options?: StatWidgetProps): void {
-    if (options?.resetOnUpdate) {
-      for (const name in options.resetOnUpdate) {
-        this._resetOnUpdate[name] = options.resetOnUpdate[name];
+  _initializeUpdateConfigs(props?: StatWidgetProps): void {
+    if (props?.resetOnUpdate) {
+      for (const name in props.resetOnUpdate) {
+        this._resetOnUpdate[name] = props.resetOnUpdate[name] || false;
       }
     }
   }
 
-  _createDOM(container: HTMLElement) {
+  _createDOM(container: HTMLElement = document.body) {
     if (typeof document === 'undefined' || !document) {
       return;
     }
 
     this._container = container;
-
-    // the widget is contained in a <div>
-    if (!this._container) {
-      this._container = document.body;
-    }
 
     // When adding the widget to an existing element, make sure there
     // is a container for this widget specifically, so that multiple widgets
@@ -197,7 +198,7 @@ export default class StatsWidget {
         this._header.style[name] = this._headerCSS[name];
       }
       this._header.onclick = this._toggleCollapsed.bind(this);
-      this._innerContainer.appendChild(this._header);
+      this._innerContainer?.appendChild(this._header);
     }
 
     this._setHeaderContent();
@@ -240,9 +241,10 @@ export default class StatsWidget {
   }
 
   _getLines(stat: Stat): string[] {
-    const formatter =
+    const formatter: StatFormatter =
       // eslint-disable-next-line
-      this._formatters[stat.name] || this._formatters[stat.type] || DEFAULT_FORMATTERS['count'];
-    return formatter(this.stats.get(stat.name)).split('\n');
+      this._formatters[stat.name] || this._formatters[stat.type] || DEFAULT_COUNT_FORMATTER;
+    // const stat = this.stats.get(stat.name);
+    return stat ? formatter(stat).split('\n') : [];
   }
 }

--- a/modules/stats-widget/test/stats-widget.spec.js
+++ b/modules/stats-widget/test/stats-widget.spec.js
@@ -58,7 +58,7 @@ test('StatsWidget#Constructor with container', t => {
   const container = _global.document.createElement('div');
   container.id = 'test-stats-widget-container';
   const statsWidget = new StatsWidget(null, {container});
-  t.ok(statsWidget._container === container);
+  t.equal(statsWidget._container, container, 'container has been set');
   statsWidget.remove();
   t.end();
 });

--- a/modules/stats-widget/tsconfig.json
+++ b/modules/stats-widget/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "exactOptionalPropertyTypes": true,
     "composite": true,
     "rootDir": "src",
     "outDir": "dist"

--- a/modules/stats/src/lib/stat.ts
+++ b/modules/stats/src/lib/stat.ts
@@ -2,14 +2,14 @@ import getHiResTimestamp from '../utils/hi-res-timestamp';
 
 export default class Stat {
   readonly name: string;
-  readonly type: string;
+  readonly type: string | undefined;
   sampleSize: number = 1;
-  time: number;
-  count: number;
-  samples: number;
-  lastTiming: number;
-  lastSampleTime: number;
-  lastSampleCount: number;
+  time: number = 0;
+  count: number = 0;
+  samples: number = 0;
+  lastTiming: number = 0;
+  lastSampleTime: number = 0;
+  lastSampleCount: number = 0;
 
   _count: number = 0;
   _time: number = 0;
@@ -21,6 +21,22 @@ export default class Stat {
     this.name = name;
     this.type = type;
     this.reset();
+  }
+
+  reset(): this {
+    this.time = 0;
+    this.count = 0;
+    this.samples = 0;
+    this.lastTiming = 0;
+    this.lastSampleTime = 0;
+    this.lastSampleCount = 0;
+    this._count = 0;
+    this._time = 0;
+    this._samples = 0;
+    this._startTime = 0;
+    this._timerPending = false;
+
+    return this;
   }
 
   setSampleSize(samples: number): this {
@@ -116,22 +132,6 @@ export default class Stat {
   /** Calculate counts per second */
   getHz(): number {
     return this.time > 0 ? this.samples / (this.time / 1000) : 0;
-  }
-
-  reset(): this {
-    this.time = 0;
-    this.count = 0;
-    this.samples = 0;
-    this.lastTiming = 0;
-    this.lastSampleTime = 0;
-    this.lastSampleCount = 0;
-    this._count = 0;
-    this._time = 0;
-    this._samples = 0;
-    this._startTime = 0;
-    this._timerPending = false;
-
-    return this;
   }
 
   _checkSampling(): void {

--- a/modules/stats/src/lib/stats.ts
+++ b/modules/stats/src/lib/stats.ts
@@ -24,7 +24,7 @@ export default class Stats {
   }
 
   /** Acquire a stat. Create if it doesn't exist. */
-  get(name: string, type: string = 'count'): Stat {
+  get(name: string, type: string = 'count'): Stat | null {
     return this._getOrCreate({name, type});
   }
 
@@ -34,16 +34,16 @@ export default class Stats {
 
   /** Reset all stats */
   reset(): this {
-    for (const key in this.stats) {
-      this.stats[key].reset();
+    for (const stat of Object.values(this.stats)) {
+      stat.reset();
     }
 
     return this;
   }
 
   forEach(fn: (stat: Stat) => void): void {
-    for (const key in this.stats) {
-      fn(this.stats[key]);
+    for (const stat of Object.values(this.stats)) {
+      fn(stat);
     }
   }
 
@@ -65,7 +65,7 @@ export default class Stats {
     stats.forEach(stat => this._getOrCreate(stat));
   }
 
-  _getOrCreate(stat: Stat | {name: string, type?: string}): Stat {
+  _getOrCreate(stat: Stat | {name: string, type?: string}): Stat | null {
     if (!stat || !stat.name) {
       return null;
     }
@@ -78,6 +78,6 @@ export default class Stats {
         this.stats[name] = new Stat(name, type);
       }
     }
-    return this.stats[name];
+    return this.stats[name] || null;
   }
 }

--- a/modules/stats/tsconfig.json
+++ b/modules/stats/tsconfig.json
@@ -3,6 +3,9 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "exactOptionalPropertyTypes": true,
     "composite": true,
     "rootDir": "src",
     "outDir": "dist"

--- a/modules/test-utils/src/utils/log-to-dom.ts
+++ b/modules/test-utils/src/utils/log-to-dom.ts
@@ -12,7 +12,7 @@ export function enableDOMLogging(options = {}): void {
     console.log = (...args) => {
       // @ts-expect-error
       logLineToDOM(options, ...args);
-      old(...args);
+      old?.(...args);
     };
   }
   if (!options && old) {

--- a/test/bench/browser.ts
+++ b/test/bench/browser.ts
@@ -33,6 +33,6 @@ suite
   .calibrate()
   .run()
   .then(() => {
-    // @ts-expect-error TS2339: Property 'browserTestDriver_finish' does not exist
+    // @ts-expect-error
     window.browserTestDriver_finish();
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,17 +26,17 @@
     "strictBindCallApply": true, // covered by strict
     "strictFunctionTypes": true, // covered by strict
     "useUnknownInCatchVariables": true,  // covered by strict
-    // "strictNullChecks": true, // covered by strict
+    "strictNullChecks": false, // covered by strict
     // "strictPropertyInitialization": true, // covered by strict, requires strict null checks
-
     // "exactOptionalPropertyTypes": true, - requires strictNullChecks
+
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": false,
+    "noUnusedParameters": false, // Not used - fixing this requires changing APIs.
     // END TYPE CHECK SETTINGS
 
     "paths": {


### PR DESCRIPTION
- `log`, `bench` and `test-utils` modules need more work (due to complex overloading or puppeteer related typing issues), other modules are now fully checked.