### PR TITLE
Fix globals bundle error

### DIFF
--- a/modules/env/src/lib/globals.ts
+++ b/modules/env/src/lib/globals.ts
@@ -1,10 +1,19 @@
-export const global = globalThis;
+// Do not name these variables the same as the global objects - will break bundling
+const global_ = globalThis;
 // eslint-disable-next-line consistent-this
-export const self = globalThis.self || globalThis.window || globalThis.global;
-export const window = (globalThis.window ||
-  globalThis.self ||
-  globalThis.global) as unknown as Window;
-export const document = globalThis.document || ({} as Document);
-export const process = globalThis.process || {};
-export const console = globalThis.console;
-export const navigator = globalThis.navigator || ({} as Navigator);
+const self_ = globalThis.self || globalThis.window || globalThis.global;
+const window_ = (globalThis.window || globalThis.self || globalThis.global) as unknown as Window;
+const document_ = globalThis.document || ({} as Document);
+const process_ = globalThis.process || {};
+const console_ = globalThis.console;
+const navigator_ = globalThis.navigator || ({} as Navigator);
+
+export {
+  global_ as global,
+  self_ as self,
+  window_ as window,
+  document_ as document,
+  process_ as process,
+  console_ as console,
+  navigator_ as navigator
+};


### PR DESCRIPTION
Vite with node polyfill throws "Identifier process is already defined"