### PR TITLE
Update babel config

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -7,6 +7,10 @@ module.exports = getBabelConfig({
     ignore: [
       // babel can't process .d.ts
       /\.d\.ts$/
-    ]
+    ],
+    assumptions: {
+      setClassMethods: true,
+      setPublicClassFields: true
+    }
   }
 });

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -8,8 +8,11 @@ module.exports = getBabelConfig({
       // babel can't process .d.ts
       /\.d\.ts$/
     ],
+    // These settings reduce the verbosity of transpile outputs
     assumptions: {
+      // When declaring classes, assume that methods don't shadow getters on the superclass and that the program doesn't depend on methods being non-enumerable.
       setClassMethods: true,
+      // When using public class fields, assume that they don't shadow any getter in the current class, in its subclasses or in its superclass.
       setPublicClassFields: true
     }
   }


### PR DESCRIPTION
Add [setPublicClassFields](https://babeljs.io/docs/assumptions#setpublicclassfields) and [setClassMethods](https://babeljs.io/docs/assumptions#setclassmethods) to babel assumptions. Significantly reduces the verbosity of the output.

After this change, the ESM entry points technically no longer need `@babel/runtime`. I left the dependency in package JSONs since `transform-runtime` is still used for transpile to ESM, in case some other references pop up later with an unintentional change.